### PR TITLE
don't use sych for ruby 2.2.0 and above

### DIFF
--- a/lib/pairwise.rb
+++ b/lib/pairwise.rb
@@ -12,14 +12,14 @@ require 'pairwise/input_file'
 require 'pairwise/cli'
 
 require 'yaml'
-if RUBY_VERSION != '1.8.7'
+if RUBY_VERSION != '1.8.7' && RUBY_VERSION < '2.2.0'
   YAML::ENGINE.yamler = 'syck' 
 end
 
 module Pairwise
   class InvalidInputData < Exception; end
 
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 
   class << self
     def combinations(*inputs)


### PR DESCRIPTION
While attempting to run pairwise with ruby 2.2.2 I encountered following error:
`/Users/sergeym/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/pairwise-0.2.1/lib/pairwise.rb:16:in '<top (required)>': uninitialized constant Psych::ENGINE (NameError)`

After searching for reason why this is happening I came across this post: https://github.com/tenderlove/syck/issues/9#issuecomment-96215418

Seems to be happier now.