### PR TITLE
syck was replaced by psych in Ruby 2.0.0, not 2.2.0.

### DIFF
--- a/lib/pairwise.rb
+++ b/lib/pairwise.rb
@@ -12,7 +12,7 @@ require 'pairwise/input_file'
 require 'pairwise/cli'
 
 require 'yaml'
-if RUBY_VERSION != '1.8.7' && RUBY_VERSION < '2.2.0'
+if RUBY_VERSION != '1.8.7' && RUBY_VERSION < '2.0.0'
   YAML::ENGINE.yamler = 'syck' 
 end
 

--- a/lib/pairwise.rb
+++ b/lib/pairwise.rb
@@ -19,7 +19,7 @@ end
 module Pairwise
   class InvalidInputData < Exception; end
 
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 
   class << self
     def combinations(*inputs)


### PR DESCRIPTION
I'm using 2.0.0 and getting the warning message: `syck has been removed, psych is used instead`

[More info](http://devblog.arnebrasseur.net/2014-02-yaml-syck-vs-psych)