### PR TITLE
Update InvalidInputData to use StandardError

### DIFF
--- a/lib/pairwise.rb
+++ b/lib/pairwise.rb
@@ -17,7 +17,7 @@ if RUBY_VERSION != '1.8.7' && RUBY_VERSION < '2.0.0'
 end
 
 module Pairwise
-  class InvalidInputData < Exception; end
+  class InvalidInputData < StandardError; end
 
   VERSION = '0.2.3'
 


### PR DESCRIPTION
Ruby best practice is to inherit from StandardError over directly inheriting from the Exception class directly. This allows for methods which catch StandardError to safely catch errors without also catching high priority Exceptions like System Interrupts.